### PR TITLE
Fixing invalid path on windows

### DIFF
--- a/helpers/getAliases/extract.js
+++ b/helpers/getAliases/extract.js
@@ -21,7 +21,7 @@ module.exports = config => {
     };
   }
 
-  if (!["src/", "node_modules/"].includes(path.normalize(baseUrl + "/"))) {
+  if (![path.normalize("src/"), path.normalize("node_modules/")].includes(path.normalize(baseUrl + "/"))) {
     return {
       result: "failure",
       error: getError(errorsKeys.INVALID_BASE_URL)


### PR DESCRIPTION
Normalizing the baseUrl validation values, to match the OS normalized value